### PR TITLE
Promise support to npmName() and inquirer.prompt()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ $ npm install --save inquirer-npm-name
 var inquirer = require('inquirer');
 var askName = require('inquirer-npm-name');
 
-//The legacy approach: Using callback
-askName({
-  name: 'name',
-  message: 'Module Name'
-}, inquirer, function (name) {
-  console.log(name);
-});
-
-//The latest approach: Using promises
 askName({
   name: 'name',
   message: 'Module Name'
@@ -43,20 +34,6 @@ var askName = require('inquirer-npm-name');
 
 module.exports = generators.Base.extend({
 
-  //The legacy approach: Using callback
-  prompting: function () {
-    var done = this.async();
-
-    askName({
-      name: 'name',
-      message: 'Module Name'
-    }, this, function (name) {
-      console.log(name);
-      done();
-    });
-  }
-
-  //The latest approach: Using promises
   prompting: function () {
 
     return askName({

--- a/README.md
+++ b/README.md
@@ -17,10 +17,19 @@ $ npm install --save inquirer-npm-name
 var inquirer = require('inquirer');
 var askName = require('inquirer-npm-name');
 
+//The legacy approach: Using callback
 askName({
   name: 'name',
   message: 'Module Name'
 }, inquirer, function (name) {
+  console.log(name);
+});
+
+//The latest approach: Using promises
+askName({
+  name: 'name',
+  message: 'Module Name'
+}, inquirer).then(function (name) {
   console.log(name);
 });
 ```
@@ -33,6 +42,8 @@ var inquirer = require('inquirer');
 var askName = require('inquirer-npm-name');
 
 module.exports = generators.Base.extend({
+
+  //The legacy approach: Using callback
   prompting: function () {
     var done = this.async();
 
@@ -44,14 +55,26 @@ module.exports = generators.Base.extend({
       done();
     });
   }
+
+  //The latest approach: Using promises
+  prompting: function () {
+
+    return askName({
+      name: 'name',
+      message: 'Module Name'
+    }, this).then(function (name) {
+      console.log(name);
+    });
+  }
 });
 ```
 
-`askName` takes 3 parameters:
+`askName` takes 2 parameters:
 
 1. `prompt` an [Inquirer prompt configuration](https://github.com/SBoudrias/Inquirer.js#question).
 2. `inquirer` or any object with a `obj.prompt()` method.
-3. The `callback` who'll take the selected name as parameter.
+
+**Returns:** A `Promise` object with `then()` chained returned from [Inquirer](https://github.com/SBoudrias/Inquirer.js) prompt.
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,36 +8,29 @@ var npmName = require('npm-name');
  * @param  {Object}   prompt   Inquirer prompt configuration
  * @param  {inquirer} inquirer Object with a `prompt` method. Usually `inquirer` or a
  *                             yeoman-generator.
- * @param  {Function} cb       Callback taking the prompt value as parameter
  */
-module.exports = function askName(prompt, inquirer, cb) {
+module.exports = function askName(prompt, inquirer) {
   var prompts = [prompt, {
     type: 'confirm',
     name: 'askAgain',
     message: 'The name above already exists on npm, choose another?',
     default: true,
     when: function (answers) {
-      var done = this.async();
 
-      npmName(answers[prompt.name], function (err, available) {
-        if (err) {
-          return done();
-        }
-
-        if (available) {
-          return done();
-        }
-
-        return done(true);
+      return npmName(answers[prompt.name]).then(function(available){
+        return !available;
       });
+
     }
   }];
 
-  inquirer.prompt(prompts, function (props) {
+  return inquirer.prompt(prompts).then(function (props) {
+
     if (props.askAgain) {
-      return askName(prompt, inquirer, cb);
+      return askName(prompt, inquirer);
     }
 
-    cb(props[prompt.name]);
+    return props;
+
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = function askName(prompt, inquirer) {
     default: true,
     when: function (answers) {
 
-      return npmName(answers[prompt.name]).then(function(available){
+      return npmName(answers[prompt.name]).then(function (available) {
         return !available;
       });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-mocha": "^2.0.0",
     "gulp-nsp": "^0.4.5",
     "gulp-plumber": "^1.0.0",
+    "pinkie-promise": "^2.0.1",
     "proxyquire": "^1.6.0",
     "sinon": "^1.15.4"
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "npm-name": "^1.1.1"
+    "npm-name": "^3.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -19,73 +19,72 @@ describe('inquirer-npm-name', function () {
 
   });
 
-  it('only ask name if name is free', function (done) {
+  it('only ask name if name is free', function () {
 
-    this.inquirer.prompt.returns(Promise.resolve({name:'foo'}));
+    this.inquirer.prompt.returns(Promise.resolve({ name: 'foo' }));
 
     return askName(this.conf, this.inquirer).then(function (props) {
       assert.equal(props.name, 'foo');
-      done();
     });
   });
 
-  it('recurse if name is taken', function (done) {
+  it('recurse if name is taken', function () {
     this.inquirer.prompt
-        .onFirstCall().returns(Promise.resolve({name: 'foo', askAgain: true}))
-        .onSecondCall().returns(Promise.resolve({name: 'bar'}));
+        .onFirstCall().returns(Promise.resolve({ name: 'foo', askAgain: true }))
+        .onSecondCall().returns(Promise.resolve({ name: 'bar' }));
 
     return askName(this.conf, this.inquirer).then(function (props) {
       assert.equal(props.name, 'bar');
-      done();
     });
   });
 
   describe('npm validation logic (inquirer `when` function)', function () {
     beforeEach(function () {
-      var askName2 = proxyquire('../lib', {
-        'npm-name': function (name, cb) {
-          cb.apply(null, this.npmNameMock);
+
+      this.askName2 = proxyquire('../lib', {
+        'npm-name': function (name) {
+          if (this.npmNameError instanceof Error) {
+            return Promise.reject(this.npmNameError);
+          }
+          return Promise.resolve(name === 'yo');
         }.bind(this)
       });
-      askName2(this.conf, this.inquirer, function () {});
-
-      this.when = this.inquirer.prompt.getCall(0).args[0][1].when;
     });
 
-    it('ask question if npm name is taken', function (done) {
-      this.npmNameMock = [null, false];
-      this.when.call({
-        async: function () {
-          return function (shouldAsk) {
-            assert.ok(shouldAsk);
-            done();
-          };
-        }
-      }, {name: 'foo'});
+    it('ask question if npm name is taken', function () {
+      this.inquirer.prompt.returns(Promise.resolve({ name: 'yo' }));
+      this.conf.name = 'yo';
+
+      return this.askName2(this.conf, this.inquirer).then(function () {
+        this.when = this.inquirer.prompt.getCall(0).args[0][1].when;
+        this.when.call(this, { name: 'yo' }).then(function (shouldAsk) {
+          assert.ok(shouldAsk);
+        });
+      }.bind(this));
     });
 
-    it('does not ask question if npm name is free', function (done) {
-      this.npmNameMock = [null, true];
-      this.when.call({
-        async: function () {
-          return function (shouldAsk) {
-            assert.equal(shouldAsk, null);
-            done();
-          };
-        }
-      }, {name: 'foo'});
+    it('does not ask question if npm name is free', function () {
+      this.inquirer.prompt.returns(Promise.resolve({ name: 'foo' }));
+
+      return this.askName2(this.conf, this.inquirer).then(function () {
+         this.when = this.inquirer.prompt.getCall(0).args[0][1].when;
+         this.when.call(this, { name: 'foo' }).then(function (shouldAsk) {
+           assert.ok(shouldAsk);
+         });
+       }.bind(this));
     });
 
-    it('does not ask if npm-name fails', function (done) {
-      this.npmNameMock = [new Error('network failure')];
-      this.when.call({
-        async: function () {
-          return function (shouldAsk) {
-            assert.equal(shouldAsk, null);
-            done();
-          };
-        }
-      }, {name: 'foo'});
+    it('does not ask if npm-name fails', function () {
+      this.inquirer.prompt.returns(Promise.resolve({ name: 'foo' }));
+
+      this.npmNameError = new Error('Network Error');
+      return this.askName2(this.conf, this.inquirer).then(function () {
+        this.when = this.inquirer.prompt.getCall(0).args[0][1].when;
+
+        return this.when.call(this, { name: 'foo' }).catch(function (err) {
+          assert.equal(err.message, 'Network Error');
+        });
+      }.bind(this));
     });
   });
 });


### PR DESCRIPTION
Change the implementation on `lib/index.js` to use **`Promise`** approach of `npm-name` and `inquirer` latest packages. This changes is related with the issue: [#158](https://github.com/yeoman/generator-generator/issues/158) from Yeoman [generator-generator](https://github.com/yeoman/generator-generator)

**Ps:** Please, Can you help me with the specs related with the `npm-name` mock? I tried change the `when()` method to new approach without success :disappointed:. 
I created a public gist with the first
code to fix these unit tests: https://gist.github.com/mfdeveloper/15bc71981615475f15333156012225e4

**Updated:** The all unit tests/specs were fixed !!
